### PR TITLE
Clean up grant/revoke for groups.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,6 @@ linters:
     - durationcheck # check for two durations multiplied together
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     - exhaustive # check exhaustiveness of enum switch statements
-    - exportloopref # checks for pointers to enclosing loop variables
     - forbidigo # Forbids identifiers
     - gochecknoinits # Checks that no init functions are present in Go code
     - goconst # Finds repeated strings that could be replaced by a constant


### PR DESCRIPTION
- Move access levels out of Entitlements. No need to create it every time we call Entitlements()
- Use the entitlement ID instead of the slug, since C1 doesn't send the whole entitlement to Grant().
- Don't error if grant is already granted/revoked.
