### PR TITLE
Goldschmidt/fix group name

### DIFF
--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -48,7 +48,7 @@ func groupResource(group *gitlabSDK.Group, parentResourceID *v2.ResourceId) (*v2
 	return resourceSdk.NewGroupResource(
 		group.FullName,
 		groupResourceType,
-		strconv.Itoa(group.ID),
+		toGroupResourceId(strconv.Itoa(group.ID)),
 		[]resourceSdk.GroupTraitOption{
 			resourceSdk.WithGroupProfile(
 				profile,
@@ -128,7 +128,12 @@ func parentResourceIsParentGroup(parentGroupId int, parentResourceID *v2.Resourc
 		return true, nil
 	}
 
-	parentId, err := strconv.Atoi(parentResourceID.Resource)
+	parentIdSegments := strings.Split(parentResourceID.Resource, "/")
+	if len(parentIdSegments) < 2 {
+		return false, fmt.Errorf("error while segmenting the parentResourceID: %v It has less than 2 segments", parentResourceID)
+	}
+
+	parentId, err := strconv.Atoi(parentIdSegments[1])
 	if err != nil {
 		return false, err
 	}

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -48,7 +48,7 @@ func groupResource(group *gitlabSDK.Group, parentResourceID *v2.ResourceId) (*v2
 	return resourceSdk.NewGroupResource(
 		group.FullName,
 		groupResourceType,
-		toGroupResourceId(strconv.Itoa(group.ID), group.Name),
+		strconv.Itoa(group.ID),
 		[]resourceSdk.GroupTraitOption{
 			resourceSdk.WithGroupProfile(
 				profile,
@@ -128,12 +128,7 @@ func parentResourceIsParentGroup(parentGroupId int, parentResourceID *v2.Resourc
 		return true, nil
 	}
 
-	parentIdSegments := strings.Split(parentResourceID.Resource, "/")
-	if len(parentIdSegments) < 2 {
-		return false, fmt.Errorf("error while segmenting the parentResourceID: %v It has less than 2 segments", parentResourceID)
-	}
-
-	parentId, err := strconv.Atoi(parentIdSegments[len(parentIdSegments)-2])
+	parentId, err := strconv.Atoi(parentResourceID.Resource)
 	if err != nil {
 		return false, err
 	}
@@ -206,7 +201,7 @@ func (o *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 	var users []*gitlabSDK.GroupMember
 	var res *gitlabSDK.Response
 	var err error
-	groupId, _, err := fromGroupResourceId(resource.Id.Resource)
+	groupId, err := fromGroupResourceId(resource.Id.Resource)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("error parsing group resource id: %w", err)
 	}
@@ -255,7 +250,7 @@ func (r *groupBuilder) Grant(
 ) {
 	l := ctxzap.Extract(ctx)
 	groupIdAndName := entitlement.Resource.Id.Resource
-	groupId, _, err := fromGroupResourceId(groupIdAndName)
+	groupId, err := fromGroupResourceId(groupIdAndName)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing group resource id: %w", err)
 	}
@@ -305,7 +300,7 @@ func (r *groupBuilder) Grant(
 
 func (r *groupBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
 	groupIdAndName := grant.Entitlement.Resource.Id.Resource
-	groupId, _, err := fromGroupResourceId(groupIdAndName)
+	groupId, err := fromGroupResourceId(groupIdAndName)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing group resource id: %w", err)
 	}

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -1,5 +1,18 @@
 package connector
 
+import (
+	"fmt"
+	"strings"
+)
+
+func toGroupResourceId(groupId string) string {
+	return fmt.Sprintf("g/%s", groupId)
+}
+
 func fromGroupResourceId(groupResourceId string) (string, error) {
-	return groupResourceId, nil
+	parts := strings.Split(groupResourceId, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid group resource id: %s", groupResourceId)
+	}
+	return parts[1], nil
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -1,18 +1,5 @@
 package connector
 
-import (
-	"fmt"
-	"strings"
-)
-
-func toGroupResourceId(groupId, groupName string) string {
-	return fmt.Sprintf("%s/%s", groupId, groupName)
-}
-
-func fromGroupResourceId(groupResourceId string) (string, string, error) {
-	parts := strings.Split(groupResourceId, "/")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid group resource id: %s", groupResourceId)
-	}
-	return parts[0], parts[1], nil
+func fromGroupResourceId(groupResourceId string) (string, error) {
+	return groupResourceId, nil
 }

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -55,7 +55,7 @@ func (o *projectBuilder) List(ctx context.Context, parentResourceID *v2.Resource
 		err       error
 	)
 
-	groupId, _, err := fromGroupResourceId(parentResourceID.Resource)
+	groupId, err := fromGroupResourceId(parentResourceID.Resource)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("error parsing group resource id: %w", err)
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -69,7 +69,7 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 
 	var groupMembers []*gitlabSDK.GroupMember
 	if parentResourceID.ResourceType == groupResourceType.Id {
-		groupId, _, err = fromGroupResourceId(parentResourceID.Resource)
+		groupId, err = fromGroupResourceId(parentResourceID.Resource)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("error parsing group resource id: %w", err)
 		}


### PR DESCRIPTION
#### Description

- [x] Bug fix
- [ ] New feature

Issue: entitlements are getting deleted if the group or project is renamed.

Group uses Id/GroupName, which we can rename to Group. This will fix the issue of missing entitlement when renamed, however, this will change all entitlements.


#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
