### PR TITLE
[BB-731] Add grantAlreadyExist to ignore parent's inherited access level error

### DIFF
--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -290,9 +290,14 @@ func (o *groupBuilder) Grant(
 
 	err = o.AddGroupMember(ctx, groupId, userId, accessLevelValue)
 	if err != nil {
-		errResp := &gitlabSDK.ErrorResponse{}
+		var errResp *gitlabSDK.ErrorResponse
 		if errors.As(err, &errResp) {
+			// Case the user has already been assigned that grant
 			if errResp.Response != nil && errResp.Response.StatusCode == http.StatusConflict {
+				return annotations.New(&v2.GrantAlreadyExists{}), nil
+			}
+			// Case: ignore error: The access level to be assigned must be higher or equal to the one inherited from the parent group.
+			if strings.Contains(err.Error(), "should be greater than or equal to") {
 				return annotations.New(&v2.GrantAlreadyExists{}), nil
 			}
 		}


### PR DESCRIPTION
#### Description

- [ ] Bug fix
- [x] New feature




#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
