### PR TITLE
Add config to only sync direct members for grants and only have project/user be a child resource type at top level 

### DIFF
--- a/cmd/baton-gitlab/main.go
+++ b/cmd/baton-gitlab/main.go
@@ -53,6 +53,7 @@ func getConnector(ctx context.Context, glc *cfg.Gitlab) (types.ConnectorServer, 
 		glc.AccessToken,
 		glc.BaseUrl,
 		glc.AccountCreationGroup,
+		glc.SyncDirectMembersOnly,
 	)
 
 	if err != nil {

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,6 +7,7 @@ type Gitlab struct {
 	AccessToken string `mapstructure:"access-token"`
 	BaseUrl string `mapstructure:"base-url"`
 	AccountCreationGroup string `mapstructure:"account-creation-group"`
+	SyncDirectMembersOnly bool `mapstructure:"sync-direct-members-only"`
 }
 
 func (c* Gitlab) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,11 @@ var (
 		field.WithDescription("The group indicated will be used as a default group for the new users. Required for account creation capability in the Cloud Version."),
 		field.WithRequired(false),
 	)
+	SyncDirectMembersOnly = field.BoolField(
+		"sync-direct-members-only",
+		field.WithDisplayName("Sync direct members only"),
+		field.WithDescription("When enabled, only sync direct members of groups and projects. Inherited members from parent groups will be excluded from membership grants."),
+	)
 
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or
@@ -33,6 +38,7 @@ var (
 		AccessToken,
 		BaseURL,
 		AccountCreationGroup,
+		SyncDirectMembersOnly,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -304,6 +304,20 @@ func (c *GitlabClient) GetProject(ctx context.Context, projectID string) (*Proje
 func (c *GitlabClient) ListProjectMembers(ctx context.Context, projectID string, nextPageToken string) ([]*ProjectMember, string, *v2.RateLimitDescription, error) {
 	var members []*ProjectMember
 
+	apiURL, _ := url.Parse(fmt.Sprintf("/api/v4/projects/%s/members", PathEscape(projectID)))
+	WithOffsetPagination(apiURL, nextPageToken)
+	headers, rateLimitDesc, err := c.doRequest(ctx, http.MethodGet, apiURL.String(), &members, nil)
+	if err != nil {
+		return nil, "", rateLimitDesc, err
+	}
+
+	nextToken := headers.Get("X-Next-Page")
+	return members, nextToken, rateLimitDesc, nil
+}
+
+func (c *GitlabClient) ListAllProjectMembers(ctx context.Context, projectID string, nextPageToken string) ([]*ProjectMember, string, *v2.RateLimitDescription, error) {
+	var members []*ProjectMember
+
 	apiURL, _ := url.Parse(fmt.Sprintf("/api/v4/projects/%s/members/all", PathEscape(projectID)))
 	WithOffsetPagination(apiURL, nextPageToken)
 	headers, rateLimitDesc, err := c.doRequest(ctx, http.MethodGet, apiURL.String(), &members, nil)

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -50,8 +50,6 @@ func New(ctx context.Context, accessToken, baseURL, accountCreationGroup string)
 }
 
 func (c *GitlabClient) doRequest(ctx context.Context, method string, endpoint string, target interface{}, body interface{}) (*http.Header, *v2.RateLimitDescription, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: do-request")
 	endpoint = fmt.Sprintf("%s%s", c.baseURL, endpoint)
 	relativeURL, err := url.Parse(endpoint)
 	if err != nil {
@@ -280,7 +278,8 @@ func (c *GitlabClient) ListProjects(ctx context.Context, groupID string, nextLin
 	endpoint := fmt.Sprintf("/api/v4/groups/%s/projects", PathEscape(groupID))
 	opts := KeysetPaginationOpts{OrderBy: "id", Sort: "asc"}
 
-	newNextLink, rateLimitDesc, err := c.listWithKeysetPagination(ctx, endpoint, nextLink, &projects, opts)
+	newNextLink, rateLimitDesc, err := c.listWithKeysetPagination(ctx, endpoint, nextLink, &projects, opts,
+		WithQueryParam("include_subgroups", "true"))
 	if err != nil {
 		return nil, "", rateLimitDesc, err
 	}

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -18,14 +18,15 @@ import (
 )
 
 type GitlabClient struct {
-	httpClient           *uhttp.BaseHttpClient
-	baseURL              string
-	AccountCreationGroup string
-	IsOnPremise          bool
-	accessToken          string
+	httpClient            *uhttp.BaseHttpClient
+	baseURL               string
+	AccountCreationGroup  string
+	IsOnPremise           bool
+	accessToken           string
+	SyncDirectMembersOnly bool
 }
 
-func New(ctx context.Context, accessToken, baseURL, accountCreationGroup string) (*GitlabClient, error) {
+func New(ctx context.Context, accessToken, baseURL, accountCreationGroup string, syncDirectMembersOnly bool) (*GitlabClient, error) {
 	options := []uhttp.Option{uhttp.WithLogger(true, ctxzap.Extract(ctx)), uhttp.WithUserAgent("baton-gitlab/1.0")}
 
 	client, err := uhttp.NewClient(ctx, options...)
@@ -41,11 +42,12 @@ func New(ctx context.Context, accessToken, baseURL, accountCreationGroup string)
 	baseURLTrimmed := strings.TrimRight(baseURL, "/")
 
 	return &GitlabClient{
-		httpClient:           httpClient,
-		baseURL:              baseURLTrimmed,
-		AccountCreationGroup: accountCreationGroup,
-		IsOnPremise:          baseURLTrimmed != "https://gitlab.com",
-		accessToken:          accessToken,
+		httpClient:            httpClient,
+		baseURL:               baseURLTrimmed,
+		AccountCreationGroup:  accountCreationGroup,
+		IsOnPremise:           baseURLTrimmed != "https://gitlab.com",
+		accessToken:           accessToken,
+		SyncDirectMembersOnly: syncDirectMembersOnly,
 	}, nil
 }
 
@@ -103,8 +105,6 @@ func (c *GitlabClient) doRequest(ctx context.Context, method string, endpoint st
 
 // ListUsers retrieves all users from GitLab API.
 func (c *GitlabClient) ListUsers(ctx context.Context, nextLink string) ([]*User, string, *v2.RateLimitDescription, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: list-users")
 	var users []*User
 	opts := KeysetPaginationOpts{OrderBy: "id", Sort: "asc"}
 
@@ -190,8 +190,6 @@ func (c *GitlabClient) ListAllGroupMembers(ctx context.Context, groupID string, 
 
 // ListGroupMembers retrieves members of a specific group.
 func (c *GitlabClient) ListGroupMembers(ctx context.Context, groupID string, nextPageToken string) ([]*GroupMember, string, *v2.RateLimitDescription, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: list-group-members")
 	var members []*GroupMember
 
 	apiURL, _ := url.Parse(fmt.Sprintf("/api/v4/groups/%s/members", PathEscape(groupID)))

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -50,6 +50,8 @@ func New(ctx context.Context, accessToken, baseURL, accountCreationGroup string)
 }
 
 func (c *GitlabClient) doRequest(ctx context.Context, method string, endpoint string, target interface{}, body interface{}) (*http.Header, *v2.RateLimitDescription, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: do-request")
 	endpoint = fmt.Sprintf("%s%s", c.baseURL, endpoint)
 	relativeURL, err := url.Parse(endpoint)
 	if err != nil {
@@ -103,6 +105,8 @@ func (c *GitlabClient) doRequest(ctx context.Context, method string, endpoint st
 
 // ListUsers retrieves all users from GitLab API.
 func (c *GitlabClient) ListUsers(ctx context.Context, nextLink string) ([]*User, string, *v2.RateLimitDescription, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: list-users")
 	var users []*User
 	opts := KeysetPaginationOpts{OrderBy: "id", Sort: "asc"}
 
@@ -188,6 +192,8 @@ func (c *GitlabClient) ListAllGroupMembers(ctx context.Context, groupID string, 
 
 // ListGroupMembers retrieves members of a specific group.
 func (c *GitlabClient) ListGroupMembers(ctx context.Context, groupID string, nextPageToken string) ([]*GroupMember, string, *v2.RateLimitDescription, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: list-group-members")
 	var members []*GroupMember
 
 	apiURL, _ := url.Parse(fmt.Sprintf("/api/v4/groups/%s/members", PathEscape(groupID)))

--- a/pkg/connector/client/helper.go
+++ b/pkg/connector/client/helper.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 type ReqOpt func(reqURL *url.URL)
@@ -64,15 +62,13 @@ func (c *GitlabClient) listWithKeysetPagination(
 		o(apiURL)
 	}
 
-	l := ctxzap.Extract(ctx)
-	l.Info("listWithKeysetPagination", zap.Any("apiURL", apiURL.String()))
 	headers, rateLimitDesc, err := c.doRequest(ctx, http.MethodGet, apiURL.String(), target, nil)
 	if err != nil {
 		return "", rateLimitDesc, err
 	}
 	linkHeader := headers.Get("Link")
 	newNextLink := parseNextLinkHeader(linkHeader)
-	l.Info("gitlab-connector: listWithKeysetPagination", zap.Any("linkHeader", linkHeader), zap.Any("newNextLink", newNextLink))
+
 	return newNextLink, rateLimitDesc, nil
 }
 

--- a/pkg/connector/client/helper.go
+++ b/pkg/connector/client/helper.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 type KeysetPaginationOpts struct {
@@ -47,6 +49,8 @@ func (c *GitlabClient) listWithKeysetPagination(
 		apiURL.RawQuery = q.Encode()
 	}
 
+	l := ctxzap.Extract(ctx)
+	l.Info("listWithKeysetPagination", zap.Any("apiURL", apiURL.String()))
 	headers, rateLimitDesc, err := c.doRequest(ctx, http.MethodGet, apiURL.String(), target, nil)
 	if err != nil {
 		return "", rateLimitDesc, err

--- a/pkg/connector/client/helper.go
+++ b/pkg/connector/client/helper.go
@@ -14,6 +14,16 @@ import (
 	"go.uber.org/zap"
 )
 
+type ReqOpt func(reqURL *url.URL)
+
+func WithQueryParam(key string, value string) ReqOpt {
+	return func(reqURL *url.URL) {
+		q := reqURL.Query()
+		q.Set(key, value)
+		reqURL.RawQuery = q.Encode()
+	}
+}
+
 type KeysetPaginationOpts struct {
 	OrderBy string
 	Sort    string
@@ -25,6 +35,7 @@ func (c *GitlabClient) listWithKeysetPagination(
 	nextLink string,
 	target interface{},
 	opts KeysetPaginationOpts,
+	reqOpts ...ReqOpt,
 ) (string, *v2.RateLimitDescription, error) {
 	endpointURL := baseEndpoint
 	if nextLink != "" {
@@ -47,6 +58,10 @@ func (c *GitlabClient) listWithKeysetPagination(
 		q.Set("sort", opts.Sort)
 		q.Set("per_page", "100")
 		apiURL.RawQuery = q.Encode()
+	}
+
+	for _, o := range reqOpts {
+		o(apiURL)
 	}
 
 	l := ctxzap.Extract(ctx)

--- a/pkg/connector/client/helper.go
+++ b/pkg/connector/client/helper.go
@@ -55,8 +55,9 @@ func (c *GitlabClient) listWithKeysetPagination(
 	if err != nil {
 		return "", rateLimitDesc, err
 	}
-
-	newNextLink := parseNextLinkHeader(headers.Get("Link"))
+	linkHeader := headers.Get("Link")
+	newNextLink := parseNextLinkHeader(linkHeader)
+	l.Info("gitlab-connector: listWithKeysetPagination", zap.Any("linkHeader", linkHeader), zap.Any("newNextLink", newNextLink))
 	return newNextLink, rateLimitDesc, nil
 }
 

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -25,11 +25,21 @@ type Group struct {
 	ParentID    int    `json:"parent_id"`
 }
 
+type Namespace struct {
+	Id       int    `json:"id"`
+	Name     string `json:"name"`
+	Path     string `json:"path"`
+	Kind     string `json:"kind"`
+	FullPath string `json:"full_path"`
+	ParentId int    `json:"parent_id"`
+}
+
 type Project struct {
-	ID                int    `json:"id"`
-	Name              string `json:"name"`
-	Description       string `json:"description"`
-	NameWithNamespace string `json:"name_with_namespace"`
+	ID                int        `json:"id"`
+	Name              string     `json:"name"`
+	Description       string     `json:"description"`
+	NameWithNamespace string     `json:"name_with_namespace"`
+	Namespace         *Namespace `json:"namespace"`
 }
 
 type GroupMember struct {
@@ -50,7 +60,7 @@ type ProjectMember struct {
 	AvatarURL         string        `json:"avatar_url"`
 	WebURL            string        `json:"web_url"`
 	AccessLevel       int           `json:"access_level"`
-	ExpiresAt         *ISOTime    `json:"expires_at"`
+	ExpiresAt         *ISOTime      `json:"expires_at"`
 	GroupSAMLIdentity *SAMLIdentity `json:"group_saml_identity"`
 	Email             string        `json:"email"`
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -89,34 +89,28 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 	var outputAnnotations = annotations.New()
 	if !d.client.IsOnPremise {
 		// If no account creation group is set, perform a general token validation.
-		_, rateLimitDesc, err := d.client.GetCurrentlyAuthenticatedUser(ctx)
-		if rateLimitDesc != nil {
-			outputAnnotations.WithRateLimiting(rateLimitDesc)
+
+		// Logic for GitLab Cloud.
+		if d.client.AccountCreationGroup != "" {
+			// If an account creation group is set, validate it exists and is unique.
+			groupName := d.client.AccountCreationGroup
+			_, rateLimitDesc, err := d.client.FindGroupByName(ctx, groupName)
+			if rateLimitDesc != nil {
+				outputAnnotations.WithRateLimiting(rateLimitDesc)
+			}
+			if err != nil {
+				return outputAnnotations, fmt.Errorf("failed to validate account creation group: %w", err)
+			}
+		} else {
+			// If no account creation group is set, perform a general token validation.
+			_, rateLimitDesc, err := d.client.GetCurrentlyAuthenticatedUser(ctx)
+			if rateLimitDesc != nil {
+				outputAnnotations.WithRateLimiting(rateLimitDesc)
+			}
+			if err != nil {
+				return outputAnnotations, fmt.Errorf("error validating token with GetCurrentlyAuthenticatedUser: %w", err)
+			}
 		}
-		if err != nil {
-			return outputAnnotations, fmt.Errorf("error validating token with GetCurrentlyAuthenticatedUser: %w", err)
-		}
-		/*	// Logic for GitLab Cloud.
-			if d.client.AccountCreationGroup != "" {
-				// If an account creation group is set, validate it exists and is unique.
-				groupName := d.client.AccountCreationGroup
-				_, rateLimitDesc, err := d.client.FindGroupByName(ctx, groupName)
-				if rateLimitDesc != nil {
-					outputAnnotations.WithRateLimiting(rateLimitDesc)
-				}
-				if err != nil {
-					return outputAnnotations, fmt.Errorf("failed to validate account creation group: %w", err)
-				}
-			} else {
-				// If no account creation group is set, perform a general token validation.
-				_, rateLimitDesc, err := d.client.GetCurrentlyAuthenticatedUser(ctx)
-				if rateLimitDesc != nil {
-					outputAnnotations.WithRateLimiting(rateLimitDesc)
-				}
-				if err != nil {
-					return outputAnnotations, fmt.Errorf("error validating token with GetCurrentlyAuthenticatedUser: %w", err)
-				}
-			}*/
 	} else {
 		// For On-Premise, validate the token can list users (requires admin permissions).
 		_, _, rateLimitDesc, err := d.client.ListUsers(ctx, "")
@@ -132,10 +126,10 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, accessToken, baseURL, accountCreationGroup string) (*Connector, error) {
+func New(ctx context.Context, accessToken string, baseURL string, accountCreationGroup string, syncDirectMembersOnly bool) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
 
-	gitlabClient, err := client.New(ctx, accessToken, baseURL, accountCreationGroup)
+	gitlabClient, err := client.New(ctx, accessToken, baseURL, accountCreationGroup, syncDirectMembersOnly)
 	if err != nil {
 		l.Error("error creating gitlab client", zap.Error(err))
 		return nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -88,27 +88,35 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, error) {
 	var outputAnnotations = annotations.New()
 	if !d.client.IsOnPremise {
-		// Logic for GitLab Cloud.
-		if d.client.AccountCreationGroup != "" {
-			// If an account creation group is set, validate it exists and is unique.
-			groupName := d.client.AccountCreationGroup
-			_, rateLimitDesc, err := d.client.FindGroupByName(ctx, groupName)
-			if rateLimitDesc != nil {
-				outputAnnotations.WithRateLimiting(rateLimitDesc)
-			}
-			if err != nil {
-				return outputAnnotations, fmt.Errorf("failed to validate account creation group: %w", err)
-			}
-		} else {
-			// If no account creation group is set, perform a general token validation.
-			_, rateLimitDesc, err := d.client.GetCurrentlyAuthenticatedUser(ctx)
-			if rateLimitDesc != nil {
-				outputAnnotations.WithRateLimiting(rateLimitDesc)
-			}
-			if err != nil {
-				return outputAnnotations, fmt.Errorf("error validating token with GetCurrentlyAuthenticatedUser: %w", err)
-			}
+		// If no account creation group is set, perform a general token validation.
+		_, rateLimitDesc, err := d.client.GetCurrentlyAuthenticatedUser(ctx)
+		if rateLimitDesc != nil {
+			outputAnnotations.WithRateLimiting(rateLimitDesc)
 		}
+		if err != nil {
+			return outputAnnotations, fmt.Errorf("error validating token with GetCurrentlyAuthenticatedUser: %w", err)
+		}
+		/*	// Logic for GitLab Cloud.
+			if d.client.AccountCreationGroup != "" {
+				// If an account creation group is set, validate it exists and is unique.
+				groupName := d.client.AccountCreationGroup
+				_, rateLimitDesc, err := d.client.FindGroupByName(ctx, groupName)
+				if rateLimitDesc != nil {
+					outputAnnotations.WithRateLimiting(rateLimitDesc)
+				}
+				if err != nil {
+					return outputAnnotations, fmt.Errorf("failed to validate account creation group: %w", err)
+				}
+			} else {
+				// If no account creation group is set, perform a general token validation.
+				_, rateLimitDesc, err := d.client.GetCurrentlyAuthenticatedUser(ctx)
+				if rateLimitDesc != nil {
+					outputAnnotations.WithRateLimiting(rateLimitDesc)
+				}
+				if err != nil {
+					return outputAnnotations, fmt.Errorf("error validating token with GetCurrentlyAuthenticatedUser: %w", err)
+				}
+			}*/
 	} else {
 		// For On-Premise, validate the token can list users (requires admin permissions).
 		_, _, rateLimitDesc, err := d.client.ListUsers(ctx, "")

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -93,6 +93,13 @@ func getParentGroup(parentGroupId int) *v2.ResourceId {
 	}
 }
 
+func getParentGroupFromNamespace(namespace *client.Namespace) *v2.ResourceId {
+	if namespace == nil {
+		return nil
+	}
+	return getParentGroup(namespace.Id)
+}
+
 func (o *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
 	rv := make([]*v2.Entitlement, 0, len(groupAccessLevels))
 
@@ -277,9 +284,11 @@ func groupResource(group *client.Group, parentResourceID *v2.ResourceId, isOnPre
 		profile["parent_group_id"] = group.ParentID
 	}
 
-	annos := []proto.Message{
-		&v2.ChildResourceType{ResourceTypeId: projectResourceType.Id},
+	annos := make([]proto.Message, 0)
+	if parentResourceID == nil {
+		annos = append(annos, &v2.ChildResourceType{ResourceTypeId: projectResourceType.Id})
 	}
+
 	// We get all members of subgroups so only need top level
 	if !isOnPremise && parentResourceID == nil {
 		annos = append(annos, &v2.ChildResourceType{ResourceTypeId: userResourceType.Id})

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -110,6 +110,8 @@ func (o *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ 
 }
 
 func (o *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: list group grants")
 	var outGrants []*v2.Grant
 	var outputAnnotations = annotations.New()
 	var users []*client.GroupMember

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -40,8 +40,6 @@ func (o *groupBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 }
 
 func (o *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: list groups", zap.Any("parentResourceID", parentResourceID))
 	if parentResourceID != nil {
 		return nil, "", nil, nil
 	}
@@ -117,8 +115,6 @@ func (o *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ 
 }
 
 func (o *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: list group grants")
 	var outGrants []*v2.Grant
 	var outputAnnotations = annotations.New()
 	var users []*client.GroupMember

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -279,9 +279,6 @@ func groupResource(group *client.Group, parentResourceID *v2.ResourceId, isOnPre
 	annotations = []proto.Message{
 		&v2.ChildResourceType{ResourceTypeId: projectResourceType.Id},
 	}
-	if !isOnPremise {
-		annotations = append(annotations, &v2.ChildResourceType{ResourceTypeId: userResourceType.Id})
-	}
 
 	return resourceSdk.NewGroupResource(
 		group.FullName,

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -277,8 +277,12 @@ func groupResource(group *client.Group, parentResourceID *v2.ResourceId, isOnPre
 		profile["parent_group_id"] = group.ParentID
 	}
 
-	annotations := []proto.Message{
+	annos := []proto.Message{
 		&v2.ChildResourceType{ResourceTypeId: projectResourceType.Id},
+	}
+	// We get all members of subgroups so only need top level
+	if !isOnPremise && parentResourceID == nil {
+		annos = append(annos, &v2.ChildResourceType{ResourceTypeId: userResourceType.Id})
 	}
 
 	return resourceSdk.NewGroupResource(
@@ -288,7 +292,7 @@ func groupResource(group *client.Group, parentResourceID *v2.ResourceId, isOnPre
 		[]resourceSdk.GroupTraitOption{
 			resourceSdk.WithGroupProfile(profile),
 		},
-		resourceSdk.WithAnnotation(annotations...),
+		resourceSdk.WithAnnotation(annos...),
 		resourceSdk.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -40,6 +40,9 @@ func (o *groupBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 }
 
 func (o *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	if parentResourceID != nil {
+		return nil, "", nil, nil
+	}
 	var (
 		groups            []*client.Group
 		outputAnnotations = annotations.New()
@@ -60,14 +63,7 @@ func (o *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 
 	outResources := make([]*v2.Resource, 0, len(groups))
 	for _, group := range groups {
-		shouldCreateResource, err := parentResourceIsParentGroup(group.ParentID, parentResourceID)
-		if err != nil {
-			return nil, "", outputAnnotations, err
-		}
-
-		if !shouldCreateResource {
-			continue
-		}
+		parentResourceID = getParentGroup(group.ParentID)
 
 		resource, err := groupResource(group, parentResourceID, o.client.IsOnPremise)
 		if err != nil {
@@ -79,32 +75,20 @@ func (o *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 	return outResources, nextPageToken, outputAnnotations, nil
 }
 
-// parentResourceIsParentGroup validates that the parentResourceID received by the function call belongs to the corresponding parent group.
-// The validation occurs between the ID on the group data (given by the API) and the ID of the parentResource.
 // parentGroupId will be 0 (zero) if the group isn't a subgroup. parentResourceID will be nil if no parent resource was received in the List function.
 // Both cases are checked and handled in this function.
-func parentResourceIsParentGroup(parentGroupId int, parentResourceID *v2.ResourceId) (bool, error) {
-	if parentGroupId != 0 && parentResourceID == nil {
+func getParentGroup(parentGroupId int) *v2.ResourceId {
+	if parentGroupId == 0 {
 		// This path occurs on the first execution of the List func. When all groups are received from the API. Subgroups will be skipped.
-		return false, nil
+		return nil
 	}
 
-	if parentResourceID == nil {
-		// If parentResourceID is null, is because it's a root group, not a subgroup, so there is no need to validate a parent group id, and it shouldn't be skipped.
-		return true, nil
+	parentGroupIdStr := strconv.Itoa(parentGroupId)
+	parentGroupResourceId := toGroupResourceId(parentGroupIdStr)
+	return &v2.ResourceId{
+		ResourceType: groupResourceType.Id,
+		Resource:     parentGroupResourceId,
 	}
-
-	parentIdSegments := strings.Split(parentResourceID.Resource, "/")
-	if len(parentIdSegments) < 2 {
-		return false, fmt.Errorf("error while segmenting the parentResourceID: %v It has less than 2 segments", parentResourceID)
-	}
-
-	parentId, err := strconv.Atoi(parentIdSegments[1])
-	if err != nil {
-		return false, err
-	}
-
-	return parentGroupId == parentId, nil
 }
 
 func (o *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -275,8 +275,7 @@ func groupResource(group *client.Group, parentResourceID *v2.ResourceId, isOnPre
 		profile["parent_group_id"] = group.ParentID
 	}
 
-	var annotations []proto.Message
-	annotations = []proto.Message{
+	annotations := []proto.Message{
 		&v2.ChildResourceType{ResourceTypeId: projectResourceType.Id},
 	}
 

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -40,6 +40,8 @@ func (o *groupBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 }
 
 func (o *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: list groups", zap.Any("parentResourceID", parentResourceID))
 	if parentResourceID != nil {
 		return nil, "", nil, nil
 	}
@@ -276,7 +278,6 @@ func groupResource(group *client.Group, parentResourceID *v2.ResourceId, isOnPre
 	var annotations []proto.Message
 	annotations = []proto.Message{
 		&v2.ChildResourceType{ResourceTypeId: projectResourceType.Id},
-		&v2.ChildResourceType{ResourceTypeId: groupResourceType.Id},
 	}
 	if !isOnPremise {
 		annotations = append(annotations, &v2.ChildResourceType{ResourceTypeId: userResourceType.Id})

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -67,7 +67,12 @@ func (o *projectBuilder) List(ctx context.Context, parentResourceID *v2.Resource
 
 	outResources := make([]*v2.Resource, 0, len(projects))
 	for _, project := range projects {
-		resource, err := projectResource(project, parentResourceID, o.client.IsOnPremise)
+		parentGroup := getParentGroupFromNamespace(project.Namespace)
+		if parentGroup == nil {
+			parentGroup = parentResourceID
+		}
+
+		resource, err := projectResource(project, parentGroup, o.client.IsOnPremise)
 		if err != nil {
 			return nil, "", outputAnnotations, err
 		}

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -14,7 +14,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -36,8 +35,6 @@ var projectAccessLevels = []client.AccessLevelValue{
 }
 
 func (o *projectBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: list projects")
 	if parentResourceID == nil {
 		return nil, "", nil, nil
 	}
@@ -83,8 +80,6 @@ func (o *projectBuilder) List(ctx context.Context, parentResourceID *v2.Resource
 }
 
 func (o *projectBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: list project entitlements")
 	rv := make([]*v2.Entitlement, 0, len(projectAccessLevels))
 
 	for _, level := range projectAccessLevels {
@@ -101,14 +96,18 @@ func (o *projectBuilder) Entitlements(ctx context.Context, resource *v2.Resource
 }
 
 func (o *projectBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: list project grants")
 	var outGrants []*v2.Grant
 	var outputAnnotations = annotations.New()
 
 	var users []*client.ProjectMember
 	var err error
-	users, nextPageToken, rateLimitDesc, err := o.client.ListProjectMembers(ctx, resource.Id.Resource, pToken.Token)
+	var nextPageToken string
+	var rateLimitDesc *v2.RateLimitDescription
+	if o.client.SyncDirectMembersOnly {
+		users, nextPageToken, rateLimitDesc, err = o.client.ListProjectMembers(ctx, resource.Id.Resource, pToken.Token)
+	} else {
+		users, nextPageToken, rateLimitDesc, err = o.client.ListAllProjectMembers(ctx, resource.Id.Resource, pToken.Token)
+	}
 	if rateLimitDesc != nil {
 		outputAnnotations.WithRateLimiting(rateLimitDesc)
 	}

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -210,11 +210,6 @@ func (o *projectBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotatio
 
 func projectResource(project *client.Project, parentResourceID *v2.ResourceId, isOnPremise bool) (*v2.Resource, error) {
 	var annotations []proto.Message
-	if !isOnPremise {
-		annotations = []proto.Message{
-			&v2.ChildResourceType{ResourceTypeId: userResourceType.Id},
-		}
-	}
 
 	return resourceSdk.NewGroupResource(
 		project.NameWithNamespace,

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -122,6 +122,7 @@ func (o *projectBuilder) Grants(ctx context.Context, resource *v2.Resource, pTok
 	}
 
 	for _, user := range users {
+
 		entitlementId := fmt.Sprintf("group:%s:%s", groupId.Resource, client.AccessLevelValue(user.AccessLevel).String())
 		principalId, err := resourceSdk.NewResourceID(userResourceType, user.ID)
 		if err != nil {
@@ -131,7 +132,7 @@ func (o *projectBuilder) Grants(ctx context.Context, resource *v2.Resource, pTok
 		grantOptions := []grant.GrantOption{
 			grant.WithAnnotation(&v2.GrantExpandable{
 				EntitlementIds: []string{entitlementId},
-				Shallow:        true,
+				Shallow:        false,
 			}),
 		}
 

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -122,7 +122,6 @@ func (o *projectBuilder) Grants(ctx context.Context, resource *v2.Resource, pTok
 	}
 
 	for _, user := range users {
-
 		entitlementId := fmt.Sprintf("group:%s:%s", groupId.Resource, client.AccessLevelValue(user.AccessLevel).String())
 		principalId, err := resourceSdk.NewResourceID(userResourceType, user.ID)
 		if err != nil {

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -14,6 +14,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -35,6 +36,8 @@ var projectAccessLevels = []client.AccessLevelValue{
 }
 
 func (o *projectBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: list projects")
 	if parentResourceID == nil {
 		return nil, "", nil, nil
 	}
@@ -74,7 +77,9 @@ func (o *projectBuilder) List(ctx context.Context, parentResourceID *v2.Resource
 	return outResources, nextPageToken, outputAnnotations, nil
 }
 
-func (o *projectBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (o *projectBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: list project entitlements")
 	rv := make([]*v2.Entitlement, 0, len(projectAccessLevels))
 
 	for _, level := range projectAccessLevels {
@@ -91,6 +96,8 @@ func (o *projectBuilder) Entitlements(_ context.Context, resource *v2.Resource, 
 }
 
 func (o *projectBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: list project grants")
 	var outGrants []*v2.Grant
 	var outputAnnotations = annotations.New()
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -15,7 +15,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/crypto"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
 const (
@@ -33,8 +32,6 @@ func (u *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
-	l := ctxzap.Extract(ctx)
-	l.Info("gitlab-connector: list users")
 	var (
 		users         []any
 		nextPageToken string

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -15,6 +15,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/crypto"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
 const (
@@ -32,6 +33,8 @@ func (u *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Info("gitlab-connector: list users")
 	var (
 		users         []any
 		nextPageToken string

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -116,7 +116,7 @@ func (u *userBuilder) listCloudVersion(ctx context.Context, parentResourceID *v2
 	case projectResourceType.Id:
 		var projectMembers []*client.ProjectMember
 		var rateLimitDescProjectMembers *v2.RateLimitDescription
-		projectMembers, nextPageToken, rateLimitDescProjectMembers, err = u.client.ListProjectMembers(ctx, parentResourceID.Resource, pToken.Token)
+		projectMembers, nextPageToken, rateLimitDescProjectMembers, err = u.client.ListAllProjectMembers(ctx, parentResourceID.Resource, pToken.Token)
 		if rateLimitDescProjectMembers != nil {
 			outputAnnotations.WithRateLimiting(rateLimitDescProjectMembers)
 		}


### PR DESCRIPTION
#### Description

- Use include_subgroups query param to include projects in subgroups of a group and only have project be a child resource type for top level groups (when `parentResourceID` is nil)
- Add config to only sync direct members for grants (group was already using direct members api so keeping that behavior the same) 

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
