### PR TITLE
[BB-1807] use SyncDirectMembersOnly logic to decide about groups memeber endpoint for grants

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -173,7 +173,7 @@ func (c *GitlabClient) GetGroup(ctx context.Context, groupID string) (*Group, *v
 	return &group, rateLimitDesc, nil
 }
 
-// ListAllGroupMembers retrieves members and pending invites of a specific group.
+// ListAllGroupMembers retrieves members and pending invites of a specific group including inherited members through ancestor groups.
 func (c *GitlabClient) ListAllGroupMembers(ctx context.Context, groupID string, nextPageToken string) ([]*GroupMember, string, *v2.RateLimitDescription, error) {
 	var members []*GroupMember
 

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -119,6 +119,11 @@ func (o *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 	var users []*client.GroupMember
 	var err error
 
+	var pageToken string
+	if pToken != nil {
+		pageToken = pToken.Token
+	}
+
 	groupId, err := fromGroupResourceId(resource.Id.Resource)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("error parsing group resource id: %w", err)
@@ -127,9 +132,9 @@ func (o *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 	var nextPageToken string
 	var rateLimitDesc *v2.RateLimitDescription
 	if o.client.SyncDirectMembersOnly {
-		users, nextPageToken, rateLimitDesc, err = o.client.ListGroupMembers(ctx, groupId, pToken.Token)
+		users, nextPageToken, rateLimitDesc, err = o.client.ListGroupMembers(ctx, groupId, pageToken)
 	} else {
-		users, nextPageToken, rateLimitDesc, err = o.client.ListAllGroupMembers(ctx, groupId, pToken.Token)
+		users, nextPageToken, rateLimitDesc, err = o.client.ListAllGroupMembers(ctx, groupId, pageToken)
 	}
 	if rateLimitDesc != nil {
 		outputAnnotations.WithRateLimiting(rateLimitDesc)

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -117,13 +117,20 @@ func (o *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 	var outGrants []*v2.Grant
 	var outputAnnotations = annotations.New()
 	var users []*client.GroupMember
+	var err error
 
 	groupId, err := fromGroupResourceId(resource.Id.Resource)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("error parsing group resource id: %w", err)
 	}
 
-	users, nextPageToken, rateLimitDesc, err := o.client.ListGroupMembers(ctx, groupId, pToken.Token)
+	var nextPageToken string
+	var rateLimitDesc *v2.RateLimitDescription
+	if o.client.SyncDirectMembersOnly {
+		users, nextPageToken, rateLimitDesc, err = o.client.ListGroupMembers(ctx, groupId, pToken.Token)
+	} else {
+		users, nextPageToken, rateLimitDesc, err = o.client.ListAllGroupMembers(ctx, groupId, pToken.Token)
+	}
 	if rateLimitDesc != nil {
 		outputAnnotations.WithRateLimiting(rateLimitDesc)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified group member retrieval behavior to note that inherited members from ancestor groups may be included.

* **New Features**
  * Added a configurable group synchronization option letting administrators choose whether to include inherited members from ancestor groups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->