### PR TITLE
[Steward] Fail pull requests when generated setup artifacts drift (bld-439b8b55ce5d9b03545cbdbd)

### DIFF
--- a/.github/workflows/capabilities_and_config.yaml
+++ b/.github/workflows/capabilities_and_config.yaml
@@ -30,16 +30,13 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - name: Build
-        run: go build -o connector ./cmd/baton-gitlab
-
-      - name: Run and save config output
-        run: ./connector config > config_schema.json
+      - name: Generate setup artifacts
+        run: make generate-setup-artifacts
 
       - name: Run and save capabilities output
         env:
           BATON_ACCESS_TOKEN: "${{ secrets.BATON_ACCESS_TOKEN }}"
-        run: ./connector capabilities --access-token=access_token --base-url=base_url --account-creation-group=group > baton_capabilities.json
+        run: ./dist/linux_amd64/baton-gitlab capabilities --access-token=access_token --base-url=base_url --account-creation-group=group > baton_capabilities.json
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
@@ -47,5 +44,6 @@ jobs:
           default_author: github_actions
           message: 'Updating baton config schema and capabilities.'
           add: |
+            pkg/config/conf.gen.go
             config_schema.json
             baton_capabilities.json

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -9,6 +9,26 @@ on:
       - main
 
 jobs:
+  setup-artifacts:
+    name: Verify setup artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Verify setup artifacts
+        run: make verify-setup-artifacts
+
   verify:
     uses: ConductorOne/github-workflows/.github/workflows/verify.yaml@v4
     with:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GOOS = $(shell go env GOOS)
 GOARCH = $(shell go env GOARCH)
 BUILD_DIR = dist/${GOOS}_${GOARCH}
 GENERATED_CONF := pkg/config/conf.gen.go
+GENERATED_SETUP_ARTIFACTS := $(GENERATED_CONF) config_schema.json
 
 ifeq ($(GOOS),windows)
 OUTPUT_PATH = ${BUILD_DIR}/baton-gitlab.exe
@@ -16,7 +17,7 @@ else
 	BUILD_TAGS=
 endif
 
-.PHONY: build
+.PHONY: build generate-setup-artifacts verify-setup-artifacts
 build: $(GENERATED_CONF)
 	go build ${BUILD_TAGS} -o ${OUTPUT_PATH} ./cmd/baton-gitlab
     
@@ -25,6 +26,22 @@ $(GENERATED_CONF): pkg/config/config.go go.mod
 	go generate ./pkg/config
     
 generate: $(GENERATED_CONF)
+
+generate-setup-artifacts:
+	@echo "Generating $(GENERATED_CONF)..."
+	go generate ./pkg/config
+	@echo "Building connector for config schema generation..."
+	go build ${BUILD_TAGS} -o ${OUTPUT_PATH} ./cmd/baton-gitlab
+	@echo "Generating config_schema.json..."
+	${OUTPUT_PATH} config > config_schema.json
+
+verify-setup-artifacts: generate-setup-artifacts
+	@stale_paths="$$(git diff --name-only -- $(GENERATED_SETUP_ARTIFACTS))"; \
+	if [ -n "$$stale_paths" ]; then \
+		echo "Setup artifacts are stale:"; \
+		printf '%s\n' "$$stale_paths"; \
+		git diff --exit-code -- $(GENERATED_SETUP_ARTIFACTS); \
+	fi
 
 .PHONY: update-deps
 update-deps:

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -11,7 +11,7 @@ type Gitlab struct {
 	SyncAccessPaths bool `mapstructure:"sync-access-paths"`
 }
 
-func (c* Gitlab) findFieldByTag(tagValue string) (any, bool) {
+func (c *Gitlab) findFieldByTag(tagValue string) (any, bool) {
 	v := reflect.ValueOf(c).Elem() // Dereference pointer to struct
 	t := v.Type()
 
@@ -43,11 +43,13 @@ func (c *Gitlab) GetString(fieldName string) string {
 	if !ok {
 		return ""
 	}
-	t, ok := v.(string)
-	if !ok {
-		panic("wrong type")
+	if t, ok := v.(string); ok {
+		return t
 	}
-	return t
+	if t, ok := v.([]byte); ok {
+		return string(t)
+	}
+	panic("wrong type")
 }
 
 func (c *Gitlab) GetInt(fieldName string) int {


### PR DESCRIPTION
Draft candidate for Steward operation bld-439b8b55ce5d9b03545cbdbd.

- Adds deterministic setup-artifact generation and drift verification.
- Runs the read-only verification on pull requests.
- Reuses the shared generator in main-branch publication.

Validation: `go test ./...`